### PR TITLE
BSON -> Serialization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,15 +4,14 @@ authors = ["Carsten Bauer <carsten.bauer@uni-paderborn.de> and contributors"]
 version = "0.1.0"
 
 [deps]
-BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [compat]
-BSON = "0.3"
 Cassette = "0.3"
 DocStringExtensions = "0.9"
 MPI = "0.20"

--- a/src/MPITape.jl
+++ b/src/MPITape.jl
@@ -4,7 +4,7 @@ using MPI
 using Cassette
 using MacroTools
 using Printf
-import BSON
+using Serialization
 using DocStringExtensions
 
 Cassette.@context MPITapeCtx

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -1,15 +1,15 @@
-default_fprefix() = "tape_rank"
+default_fprefix() = "rank"
 default_fname() = default_fprefix() * string(getrank())
-default_fext() = ".bson"
+default_fext() = ".tape"
 default_fname_full() = default_fname() * default_fext()
 
 function save(fname = default_fname_full())
-    BSON.bson(fname, Dict(:tape => unsafe_gettape()))
+    serialize(fname, unsafe_gettape())
     return nothing
 end
 
 function read(fname = default_fname_full())
-    tape_from_file = BSON.load(fname)[:tape]
+    tape_from_file = deserialize(fname)
     return tape_from_file
 end
 


### PR DESCRIPTION
In this PR we switch from using BSON.jl as the backend for our file io to simply using the Serialization stdlib. Tape files are now named e.g. `rank3.tape`.

Advantages:
* Simple
* Fast
* Small tape files

Disadvantages:
* No compatibility guarantee across Julia versions.
* Tape files might not be correctly readable on different machines.

Closes #5