### PR TITLE
Refactor overdubbing

### DIFF
--- a/src/MPITape.jl
+++ b/src/MPITape.jl
@@ -11,9 +11,9 @@ Cassette.@context MPITapeCtx
 
 include("utils.jl")
 include("mpievent.jl")
+include("api.jl")
 include("mpifuncs_overdubbing.jl")
 include("printing.jl")
-include("api.jl")
 include("fileio.jl")
 include("communication_graph.jl")
 include("plotting.jl")

--- a/src/api.jl
+++ b/src/api.jl
@@ -9,12 +9,21 @@ end
 
 reset() = empty!(unsafe_gettape())
 
+"""
+Holding data that is required to be exchanged between `prehook` and `posthook` 
+(i.e. the start time of the call)
+"""
+mutable struct MPIEventTrace
+    start_time::Float64
+    MPIEventTrace() = new(0.0)
+end
+
 function record(f, args...)
     MPITape.reset()
     mpi_maybeinit()
     MPI.Barrier(MPI.COMM_WORLD)
     TIME_START[] = MPI.Wtime()
-    result = Cassette.overdub(MPITapeCtx(), f, args...)
+    result = Cassette.overdub(MPITapeCtx(metadata = MPIEventTrace()), f, args...)
     return result
 end
 

--- a/test/mpitest_basic.jl
+++ b/test/mpitest_basic.jl
@@ -28,6 +28,7 @@ end
 if rank == 0 # Master
     tape_merged = MPITape.readall_and_merge()
     @test typeof(tape_merged) == Vector{MPITape.MPIEvent}
+    @test length(tape_merged) > 0
     @test isnothing(MPITape.print_merged(tape_merged))
     @test typeof(MPITape.plot_sequence_merged(tape_merged)) == Kroki.Diagram
     @test isnothing(MPITape.plot_merged(tape_merged))

--- a/test/mpitest_bcast_reduce.jl
+++ b/test/mpitest_bcast_reduce.jl
@@ -29,6 +29,7 @@ end
 if rank == 0 # Master
     tape_merged = MPITape.readall_and_merge()
     @test typeof(tape_merged) == Vector{MPITape.MPIEvent}
+    @test length(tape_merged) > 0
     @test isnothing(MPITape.print_merged(tape_merged))
     @test typeof(MPITape.plot_sequence_merged(tape_merged)) == Kroki.Diagram
     @test isnothing(MPITape.plot_merged(tape_merged))


### PR DESCRIPTION
Use `Cassette.prehook` and `Cassette.posthook` to collect data instead of `overdub`. This is slightly cleaner code for our use case.